### PR TITLE
Resource resolution from array

### DIFF
--- a/src/TRMap.php
+++ b/src/TRMap.php
@@ -67,11 +67,20 @@ class TRMap extends Field
 
     public function resolve($resource, $attribute = null)
     {
-        if ($resource->getAttribute('latitude')) {
-            $this->latitude(floatval($resource->getAttribute('latitude')));
-        }
-        if ($resource->getAttribute('longitude')) {
-            $this->longitude(floatval($resource->getAttribute('longitude')));
+        if (is_array($resource)) {
+            if ($resource['latitude']) {
+                $this->latitude(floatval($resource['latitude']));
+            }
+            if ($resource['longitude']) {
+                $this->longitude(floatval($resource['longitude']));
+            }
+        } else {
+            if ($resource->getAttribute('latitude')) {
+                $this->latitude(floatval($resource->getAttribute('latitude')));
+            }
+            if ($resource->getAttribute('longitude')) {
+                $this->longitude(floatval($resource->getAttribute('longitude')));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/trinity-rank/google-map-with-autocomplete/issues/4

Some packages, like [Nova Flexible Content](https://github.com/whitecube/nova-flexible-content) provide the resource to the field as an array, thus getAttribute() calls fail causing an error. This PR fixes the bug by first checking if $resource is an array