### PR TITLE
Added the ability to prevent the Nova form submission upon selecting & pressing enter on an address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ TRZipCode::make('Zip Code'), // Zip Code Filed
 TRAddress::make('Address'), // Autocomplete address field
 ```
 
-Add the use declaration to your resource and use the panel with all fileds:
+Add the use declaration to your resource and use the panel with all fields:
 
 ```php
 use Trinityrank\GoogleMapWithAutocomplete\TRLocation;
 
-TRLocation::make('Location'), // All fileds in panel with required rule
+TRLocation::make('Location'), // All fields in panel with required rule
 ```
 
 ![Image of character counter](docs/screenshot-fields.png)
 
 ### Customize Fields
 
-Add custom latitude, longitude and zoom values for starting point
+Add custom latitude, longitude and zoom values for starting point:
 
 ```php
 TRMap::make('Map')
@@ -66,7 +66,7 @@ TRMap::make('Map')
     ->zoom('zoom'),
 ```
 
-Hide latitude and longitude field
+Hide latitude and longitude field:
 
 ```php
 TRMap::make('Map')
@@ -74,4 +74,11 @@ TRMap::make('Map')
     ->hideLongitude(),
 ```
 
-You can add any nova basic methods to fileds (Showing / Hiding, Validation ... ).
+Prevent form submission when pressing the enter key in a Nova model:
+
+```php
+TRAddress::make('Address')
+    ->preventEnter(),
+```
+
+You can add any nova basic methods to fields (Showing / Hiding, Validation ... ).

--- a/resources/js/components/TRAddress/FormField.vue
+++ b/resources/js/components/TRAddress/FormField.vue
@@ -11,6 +11,7 @@
                 :class="errorClasses"
                 @place_changed="setPlace"
                 autocomplete="nope"
+                @keypress.enter="preventEnter"
             />
         </template>
     </DefaultField>
@@ -26,7 +27,8 @@ export default {
 
     data() {
         return {
-            value: null
+            value: null,
+            preventEnter: null
         }
     },
 
@@ -57,6 +59,9 @@ export default {
          */
         fill(formData) {
             formData.append(this.field.attribute, this.value || '')
+        },
+        preventEnter(event) {
+            this.field.preventEnter && event.preventDefault();
         },
         setPlace(place) {
             for (const component of place.address_components) {

--- a/src/TRAddress.php
+++ b/src/TRAddress.php
@@ -11,4 +11,9 @@ class TRAddress extends Field
      * @var string
      */
     public $component = 'tr-address';
+
+    public function preventEnter()
+    {
+        return $this->withMeta(['preventEnter' => true]);
+    }
 }


### PR DESCRIPTION
In TRAddress, after you start typing an address and receive suggestions, you can then use the arrow key to navigate down the list. You can then press enter to select this selection. 

The problem with this is that this then also submits the form! In the case of the Nova Model edit - this tries to save the model. 

This simple fix enables an option that eliminates this functionality, while keeping the default the same for folks who don't want backwards compatibility issues. 